### PR TITLE
[Bug Fix] Window Size loaded on the server

### DIFF
--- a/src/lib/hooks/useWindowSize.ts
+++ b/src/lib/hooks/useWindowSize.ts
@@ -1,13 +1,11 @@
 import { useEffect, useState } from "react";
 
 export default function useWindowSize() {
+  // Initialize to zero before mount since we don't know the window size yet
   const [windowSize, setWindowSize] = useState<{
     width: number | undefined;
     height: number | undefined;
-  }>({
-    width: window.innerWidth,
-    height: window.innerHeight,
-  });
+  }>({ width: 0, height: 0 });
 
   useEffect(() => {
     // Handler to call on window resize


### PR DESCRIPTION
This PR fixes a bug where `useWindowSize` would attempt to calculate window width and height while both being _imported_ and when being called, meaning that it would sometimes attempt to read this size while on the server or before the component mounts, throwing an error. This did not lead to app crashes (to my knowledge), but it did lead to extraneous error logs and decreased app performance in development.

Now, window size is only calculated when the hook is _called_ and defaults to `0` by `0` on import. App behavior is unchanged.

It's important to note that this is just a stopgap solution to address errors – I plan on refactoring the app to use responsive tailwind breakpoints to handle app resizing and web vs mobile in the future.